### PR TITLE
Fixing typo in FromConfig method.

### DIFF
--- a/Aqueduct.Toggles/LayoutToggle.cs
+++ b/Aqueduct.Toggles/LayoutToggle.cs
@@ -22,7 +22,7 @@ namespace Aqueduct.Toggles
             {
                 Id = element.Id,
                 New = element.New,
-                Renderings = element.Renderings.Cast<FeatureToggleLayoutRenderingConfigurationElement>().Select(LayoutToggleRendering.FromConfing).ToList()
+                Renderings = element.Renderings.Cast<FeatureToggleLayoutRenderingConfigurationElement>().Select(LayoutToggleRendering.FromConfig).ToList()
             };
         }
     }

--- a/Aqueduct.Toggles/LayoutToggleRendering.cs
+++ b/Aqueduct.Toggles/LayoutToggleRendering.cs
@@ -9,7 +9,7 @@ namespace Aqueduct.Toggles
         public string PlaceHolder { get; set; }
         public Guid SublayoutId { get; set; }
 
-        internal static LayoutToggleRendering FromConfing(FeatureToggleLayoutRenderingConfigurationElement element)
+        internal static LayoutToggleRendering FromConfig(FeatureToggleLayoutRenderingConfigurationElement element)
         {
             return new LayoutToggleRendering
             {


### PR DESCRIPTION
Minor typo in method name I noticed when pulling down the solution.